### PR TITLE
Only hide the keyboard on phones

### DIFF
--- a/Elsewhen/Views/TimeCodeGeneratorView.swift
+++ b/Elsewhen/Views/TimeCodeGeneratorView.swift
@@ -98,17 +98,6 @@ private extension TimeCodeGeneratorView {
     }
 }
 
-extension UIDevice {
-    static var isIPad: Bool {
-        UIDevice.current.userInterfaceIdiom == .pad
-    }
-    
-    static var isIPhone: Bool {
-        UIDevice.current.userInterfaceIdiom == .phone
-    }
-}
-
-
 struct TimeCodeGeneratorView_Previews: PreviewProvider {
     static var previews: some View {
         TimeCodeGeneratorView()

--- a/Elsewhen/Views/TimeCodeGeneratorView.swift
+++ b/Elsewhen/Views/TimeCodeGeneratorView.swift
@@ -77,8 +77,10 @@ struct TimeCodeGeneratorView: View, KeyboardReadable {
             showLocalTimeInstead = false
         }
         .onReceive(keyboardPublisher) { newIsKeyboardVisible in
-                        isKeyboardVisible = newIsKeyboardVisible
-                    }
+            if UIDevice.current.userInterfaceIdiom == .phone {
+                isKeyboardVisible = newIsKeyboardVisible
+            }
+        }
     }
     
     func convertSelectedDate(from initialTimezone: TimeZone, to targetTimezone: TimeZone) -> Date {
@@ -95,6 +97,17 @@ private extension TimeCodeGeneratorView {
         }
     }
 }
+
+extension UIDevice {
+    static var isIPad: Bool {
+        UIDevice.current.userInterfaceIdiom == .pad
+    }
+    
+    static var isIPhone: Bool {
+        UIDevice.current.userInterfaceIdiom == .phone
+    }
+}
+
 
 struct TimeCodeGeneratorView_Previews: PreviewProvider {
     static var previews: some View {


### PR DESCRIPTION
Previous fix that hid the results view when the keyboard is shown also affected the iPad. This restricts it to just phones.