### PR TITLE
Change behaviour of the relative time button

### DIFF
--- a/Elsewhen/Elements/DateTimeSelection.swift
+++ b/Elsewhen/Elements/DateTimeSelection.swift
@@ -11,6 +11,7 @@ struct DateTimeSelection: View {
     @Binding var selectedFormatStyle: DateFormat
     @Binding var selectedDate: Date
     @Binding var selectedTimeZone: TimeZone
+    @Binding var appendRelative: Bool
     
 #if os(iOS)
     let mediumImpactFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
@@ -26,7 +27,11 @@ struct DateTimeSelection: View {
             HStack(spacing: 5) {
                 ForEach(dateFormats, id: \.self) { formatStyle in
                     Button(action: {
-                        self.selectedFormatStyle = formatStyle
+                        if self.selectedFormatStyle == formatStyle && appendRelative {
+                            self.selectedFormatStyle = relativeDateFormat
+                        } else {
+                            self.selectedFormatStyle = formatStyle
+                        }
                     }) {
                         Label(formatStyle.name, systemImage: formatStyle.icon)
                             .labelStyle(IconOnlyLabelStyle())
@@ -39,6 +44,22 @@ struct DateTimeSelection: View {
                             )
                     }.buttonStyle(PlainButtonStyle())
                 }
+                Button(action: {
+                    if self.selectedFormatStyle != relativeDateFormat {
+                        self.appendRelative.toggle()
+                    }
+                }) {
+                    Label(relativeDateFormat.name, systemImage: relativeDateFormat.icon)
+                        .labelStyle(IconOnlyLabelStyle())
+                        .foregroundColor(appendRelative && selectedFormatStyle != relativeDateFormat ? .secondary : .white)
+                        .font(.title)
+                        .frame(width: 50, height: 50)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                .strokeBorder(appendRelative && selectedFormatStyle != relativeDateFormat ? Color.accentColor : Color.clear, lineWidth: 3)
+                                .background(RoundedRectangle(cornerRadius: 10, style: .continuous).fill(appendRelative ? (selectedFormatStyle == relativeDateFormat ? Color.accentColor : Color(UIColor.secondarySystemBackground)) : .secondary))
+                        )
+                }.buttonStyle(PlainButtonStyle())
             }
             .padding(.bottom, 10)
             .background(GeometryReader { geometry in

--- a/Elsewhen/Elements/DiscordFormattedDate.swift
+++ b/Elsewhen/Elements/DiscordFormattedDate.swift
@@ -14,6 +14,7 @@ struct DiscordFormattedDate: View {
     var body: some View {
         Text(text)
             .font(.system(.body, design: .monospaced))
+            .multilineTextAlignment(.center)
             .foregroundColor(.secondary)
             .onDrag {
                 return NSItemProvider(item: text.data(using: .utf8)! as NSData, typeIdentifier: UTType.utf8PlainText.identifier)

--- a/Elsewhen/Elements/ResultSheet.swift
+++ b/Elsewhen/Elements/ResultSheet.swift
@@ -13,6 +13,7 @@ struct ResultSheet: View {
     let selectedDate: Date
     let selectedTimeZone: TimeZone
     let discordFormat: String
+    let appendRelative: Bool
     @Binding var showLocalTimeInstead: Bool
     @Binding var selectedFormatStyle: DateFormat
     
@@ -24,20 +25,29 @@ struct ResultSheet: View {
     @State private var notificationFeedbackGenerator: UINotificationFeedbackGenerator? = nil
     #endif
     
+    private func getDateFormat(date: Date, in timezone: TimeZone, with formatCode: FormatCode) -> String {
+        var formatted = format(date: date, in: timezone, with: formatCode)
+        if appendRelative && formatCode != .R {
+            let relative = format(date: date, in: timezone, with: FormatCode.R)
+            formatted = "\(formatted) (\(relative))"
+        }
+        return formatted
+    }
+    
     var body: some View {
         VStack {
             VStack {
                 
                 if !showLocalTimeInstead {
                     
-                    Text(format(date: convertSelectedDate(from: selectedTimeZone, to: selectedTimeZone), in: selectedTimeZone, with: selectedFormatStyle.code))
+                    Text(getDateFormat(date: convertSelectedDate(from: selectedTimeZone, to: selectedTimeZone), in: selectedTimeZone, with: selectedFormatStyle.code))
                         .multilineTextAlignment(.center)
                         .font(.headline)
                         .foregroundColor(.primary)
                     
                 } else {
                     
-                    Text(format(date: convertSelectedDate(from: selectedTimeZone, to: TimeZone.current), in: TimeZone.current, with: selectedFormatStyle.code))
+                    Text(getDateFormat(date: convertSelectedDate(from: selectedTimeZone, to: TimeZone.current), in: TimeZone.current, with: selectedFormatStyle.code))
                         .multilineTextAlignment(.center)
                         .font(.headline)
                         .foregroundColor(.primary)

--- a/Elsewhen/Helpers/DateHelpers.swift
+++ b/Elsewhen/Helpers/DateHelpers.swift
@@ -29,9 +29,10 @@ let dateFormats: [DateFormat] = [
     DateFormat(icon: "calendar.badge.plus", name: "Full with Day", code: .F),
     DateFormat(icon: "calendar", name: "Date only", code: .D),
     DateFormat(icon: "clock", name: "Time only", code: .t),
-    DateFormat(icon: "clock.fill", name: "Time with seconds", code: .T),
-    DateFormat(icon: "clock.arrow.2.circlepath", name: "Relative", code: .R),
+    DateFormat(icon: "clock.fill", name: "Time with seconds", code: .T)
 ]
+
+let relativeDateFormat = DateFormat(icon: "clock.arrow.2.circlepath", name: "Relative", code: .R)
 
 func convert(date: Date, from initialTimezone: TimeZone, to targetTimezone: TimeZone) -> Date {
     let offset = TimeInterval(targetTimezone.secondsFromGMT(for: date) - initialTimezone.secondsFromGMT(for: date))

--- a/Elsewhen/Views/TimeCodeGeneratorView.swift
+++ b/Elsewhen/Views/TimeCodeGeneratorView.swift
@@ -14,7 +14,7 @@ struct TimeCodeGeneratorView: View, KeyboardReadable {
     @State private var selectedTimeZone: TimeZone = TimeZone.current
     @State private var selectedFormatStyle: DateFormat = dateFormats[0]
     @State private var showLocalTimeInstead: Bool = false
-    @State private var appendRelative: Bool = true
+    @State private var appendRelative: Bool = false
     
     @State private var resultSheetMaxHeight: CGFloat?
     

--- a/Elsewhen/Views/TimeCodeGeneratorView.swift
+++ b/Elsewhen/Views/TimeCodeGeneratorView.swift
@@ -14,6 +14,7 @@ struct TimeCodeGeneratorView: View, KeyboardReadable {
     @State private var selectedTimeZone: TimeZone = TimeZone.current
     @State private var selectedFormatStyle: DateFormat = dateFormats[0]
     @State private var showLocalTimeInstead: Bool = false
+    @State private var appendRelative: Bool = true
     
     @State private var resultSheetMaxHeight: CGFloat?
     
@@ -24,7 +25,11 @@ struct TimeCodeGeneratorView: View, KeyboardReadable {
     
     private var discordFormat: String {
         let timeIntervalSince1970 = Int(convertSelectedDate(from: selectedTimeZone, to: TimeZone.current).timeIntervalSince1970)
-        return "<t:\(timeIntervalSince1970):\(selectedFormatStyle.code.rawValue)>"
+        var returnString = "<t:\(timeIntervalSince1970):\(selectedFormatStyle.code.rawValue)>"
+        if appendRelative && selectedFormatStyle != relativeDateFormat {
+            returnString = "\(returnString) (<t:\(timeIntervalSince1970):\(relativeDateFormat.code.rawValue)>)"
+        }
+        return returnString
     }
     
     var body: some View {
@@ -34,7 +39,7 @@ struct TimeCodeGeneratorView: View, KeyboardReadable {
                 Rectangle().fill(Color.clear).frame(height: 1)
                 ScrollView {
                     
-                    DateTimeSelection(selectedFormatStyle: $selectedFormatStyle, selectedDate: $selectedDate, selectedTimeZone: $selectedTimeZone)
+                    DateTimeSelection(selectedFormatStyle: $selectedFormatStyle, selectedDate: $selectedDate, selectedTimeZone: $selectedTimeZone, appendRelative: $appendRelative)
                     
                     VStack(spacing: 0) {
                     
@@ -60,7 +65,7 @@ struct TimeCodeGeneratorView: View, KeyboardReadable {
                 }
             }
             if !isKeyboardVisible {
-                ResultSheet(selectedDate: selectedDate, selectedTimeZone: selectedTimeZone, discordFormat: discordFormat, showLocalTimeInstead: $showLocalTimeInstead, selectedFormatStyle: $selectedFormatStyle)
+                ResultSheet(selectedDate: selectedDate, selectedTimeZone: selectedTimeZone, discordFormat: discordFormat, appendRelative: appendRelative, showLocalTimeInstead: $showLocalTimeInstead, selectedFormatStyle: $selectedFormatStyle)
                     .opacity(showResultsSheet ? 1 : 0)
                     .background(GeometryReader { geometry in
                         Color.clear.preference(


### PR DESCRIPTION
This PR changes the behaviour of the relative time button, from being just another display choice, to being a toggle to let the user append the relative time in brackets to one of the other display choices.

The pure relative time by itself can be accessed by turning relative time on, and turning off the currently chosen display type.