### PR TITLE
Prevent disconnection of share sheet on iPhone

### DIFF
--- a/Elsewhen.xcodeproj/project.pbxproj
+++ b/Elsewhen.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		5EE2D2CF26F28CE100D61875 /* KeyboardHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EE2D2CE26F28CE000D61875 /* KeyboardHelpers.swift */; };
 		5EE70E2726ECCC0700F3F164 /* TimeCodeGeneratorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EE70E2626ECCC0700F3F164 /* TimeCodeGeneratorView.swift */; };
 		5EE70E2A26ED21AA00F3F164 /* DateTimeZonePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EE70E2926ED21AA00F3F164 /* DateTimeZonePicker.swift */; };
+		63087E97271B633700D6EEE8 /* NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63087E96271B633500D6EEE8 /* NotificationName.swift */; };
 		631E3F2226FCE9B60025F080 /* SelectedTimeZoneCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631E3F2126FCE9B60025F080 /* SelectedTimeZoneCell.swift */; };
 		631E3F2326FCEC140025F080 /* SelectedTimeZoneCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631E3F2126FCE9B60025F080 /* SelectedTimeZoneCell.swift */; };
 		631E3F2526FCEF1F0025F080 /* DeleteButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631E3F2426FCEF1F0025F080 /* DeleteButton.swift */; };
@@ -91,6 +92,7 @@
 		637839C126ECBA5B0055A10D /* NSUserInfoKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637839C026ECBA5B0055A10D /* NSUserInfoKeys.swift */; };
 		637839C226ECBA680055A10D /* NSUserInfoKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637839C026ECBA5B0055A10D /* NSUserInfoKeys.swift */; };
 		637839CB26ED11360055A10D /* TimeZone+ItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637839CA26ED11360055A10D /* TimeZone+ItemProvider.swift */; };
+		63814C9A271B719D00D900D2 /* NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63087E96271B633500D6EEE8 /* NotificationName.swift */; };
 		638A72D62711B75C00E0171D /* TimeZone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638A72D52711B75C00E0171D /* TimeZone.swift */; };
 		638A72D72711B77300E0171D /* TimeZone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638A72D52711B75C00E0171D /* TimeZone.swift */; };
 		638A72D82711B77300E0171D /* TimeZone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638A72D52711B75C00E0171D /* TimeZone.swift */; };
@@ -126,6 +128,8 @@
 		63B0886227108DEF00CA9980 /* TimeListIntentHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B0886127108DEF00CA9980 /* TimeListIntentHandling.swift */; };
 		63B08863271097AF00CA9980 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9BD45026EEA11900383233 /* UserDefaults.swift */; };
 		63B0886527109E6200CA9980 /* CommonResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B0886427109E6200CA9980 /* CommonResolution.swift */; };
+		63BB87BB271B6B41000E8820 /* SharingHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB87BA271B6B41000E8820 /* SharingHelpers.swift */; };
+		63BB87BC271B6B65000E8820 /* SharingHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BB87BA271B6B41000E8820 /* SharingHelpers.swift */; };
 		63C51BA526F9C9C900145662 /* SelectTimeZoneWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C51BA426F9C9C900145662 /* SelectTimeZoneWindowController.swift */; };
 		63C51BA726FA32D400145662 /* FavouriteIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C51BA626FA32D400145662 /* FavouriteIndicator.swift */; };
 		63C51BA826FA333200145662 /* FavouriteIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C51BA626FA32D400145662 /* FavouriteIndicator.swift */; };
@@ -202,6 +206,7 @@
 		5EE2D2CE26F28CE000D61875 /* KeyboardHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardHelpers.swift; sourceTree = "<group>"; };
 		5EE70E2626ECCC0700F3F164 /* TimeCodeGeneratorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeCodeGeneratorView.swift; sourceTree = "<group>"; };
 		5EE70E2926ED21AA00F3F164 /* DateTimeZonePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTimeZonePicker.swift; sourceTree = "<group>"; };
+		63087E96271B633500D6EEE8 /* NotificationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationName.swift; sourceTree = "<group>"; };
 		631E3F2126FCE9B60025F080 /* SelectedTimeZoneCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedTimeZoneCell.swift; sourceTree = "<group>"; };
 		631E3F2426FCEF1F0025F080 /* DeleteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteButton.swift; sourceTree = "<group>"; };
 		6346AD5A26F3BF1300E406D0 /* MacElsewhen.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MacElsewhen.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -266,6 +271,7 @@
 		63A915F626FB42CE0027B18D /* StarUnstarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarUnstarButton.swift; sourceTree = "<group>"; };
 		63B0886127108DEF00CA9980 /* TimeListIntentHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeListIntentHandling.swift; sourceTree = "<group>"; };
 		63B0886427109E6200CA9980 /* CommonResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonResolution.swift; sourceTree = "<group>"; };
+		63BB87BA271B6B41000E8820 /* SharingHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharingHelpers.swift; sourceTree = "<group>"; };
 		63C51BA426F9C9C900145662 /* SelectTimeZoneWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectTimeZoneWindowController.swift; sourceTree = "<group>"; };
 		63C51BA626FA32D400145662 /* FavouriteIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavouriteIndicator.swift; sourceTree = "<group>"; };
 		63C51BAA26FA343600145662 /* TimeZoneChoiceCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZoneChoiceCell.swift; sourceTree = "<group>"; };
@@ -397,6 +403,7 @@
 				5EE2D2CE26F28CE000D61875 /* KeyboardHelpers.swift */,
 				6346AD9926F3C33D00E406D0 /* PasteboardHelpers.swift */,
 				5E5F42B727163E500022C7D1 /* Orientation.swift */,
+				63BB87BA271B6B41000E8820 /* SharingHelpers.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -470,6 +477,7 @@
 				5E9BD45026EEA11900383233 /* UserDefaults.swift */,
 				6346AD9C26F3C4EE00E406D0 /* Color.swift */,
 				63A90DCF26F4295F00CACCB9 /* Bundle.swift */,
+				63087E96271B633500D6EEE8 /* NotificationName.swift */,
 				638A72D52711B75C00E0171D /* TimeZone.swift */,
 				638A72DB2711D9A600E0171D /* TimeInterval.swift */,
 			);
@@ -853,6 +861,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				63087E97271B633700D6EEE8 /* NotificationName.swift in Sources */,
 				6346ADA526F3D4E600E406D0 /* SelectTimeZoneButton.swift in Sources */,
 				638A72DC2711D9A600E0171D /* TimeInterval.swift in Sources */,
 				5EE70E2A26ED21AA00F3F164 /* DateTimeZonePicker.swift in Sources */,
@@ -861,6 +870,7 @@
 				5EB23B9F26E406B600203153 /* ContentView.swift in Sources */,
 				6346AD9D26F3C4EE00E406D0 /* Color.swift in Sources */,
 				6346AD9A26F3C33D00E406D0 /* PasteboardHelpers.swift in Sources */,
+				63BB87BB271B6B41000E8820 /* SharingHelpers.swift in Sources */,
 				6378397E26EA5FD60055A10D /* UIApplication+clearLaunchScreenCache.swift in Sources */,
 				5E9BD45926EF44B700383233 /* MykeMode.swift in Sources */,
 				63C51BAB26FA343600145662 /* TimeZoneChoiceCell.swift in Sources */,
@@ -909,6 +919,7 @@
 				6346AD9326F3C1F400E406D0 /* DateTimeZonePicker.swift in Sources */,
 				6346AD8B26F3C1A100E406D0 /* MykeMode.swift in Sources */,
 				6346AD9426F3C1F800E406D0 /* TimeZoneChoiceItem.swift in Sources */,
+				63BB87BC271B6B65000E8820 /* SharingHelpers.swift in Sources */,
 				6346AD9026F3C1EC00E406D0 /* TimezoneChoiceView.swift in Sources */,
 				6346AD9826F3C2B800E406D0 /* TimeZoneFlags.swift in Sources */,
 				63C51BAC26FA346B00145662 /* TimeZoneChoiceCell.swift in Sources */,
@@ -936,6 +947,7 @@
 				63A90DF426F5F3A000CACCB9 /* MacContentView.swift in Sources */,
 				63A90DF526F5F6A000CACCB9 /* ContentView.swift in Sources */,
 				6346AD9526F3C22C00E406D0 /* UserDefaults.swift in Sources */,
+				63814C9A271B719D00D900D2 /* NotificationName.swift in Sources */,
 				638A72DD2711D9CB00E0171D /* TimeInterval.swift in Sources */,
 				63A90DE826F4D49E00CACCB9 /* MenuItemContents.swift in Sources */,
 				63A90DC326F4255E00CACCB9 /* WindowManager.swift in Sources */,

--- a/Elsewhen/ContentView.swift
+++ b/Elsewhen/ContentView.swift
@@ -15,6 +15,7 @@ import os.log
 struct ContentView: View {
     
     @State private var selectedTab: Int = 0
+    @State private var showShareSheet: ShareSheetItem? = nil
     
     init() {
 #if canImport(UIKit)
@@ -45,7 +46,17 @@ struct ContentView: View {
                 .tag(1)
             
         }
-            
+        .sheet(item: $showShareSheet) { item in
+            #if !os(macOS)
+            ActivityView(activityItems: item.items)
+            #endif
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .EWShouldOpenShareSheet, object: appDelegate())) { notification in
+            guard let activityItems = notification.userInfo?[ActivityItemsKey] as? [Any] else {
+                return
+            }
+            showShareSheet = .init(items: activityItems)
+        }
     }
     
 }

--- a/Elsewhen/Elements/Buttons/ShareButton.swift
+++ b/Elsewhen/Elements/Buttons/ShareButton.swift
@@ -11,7 +11,6 @@ struct ShareButton: View {
     
     let generateText: () -> String
     
-    @State private var showShareSheet: Bool = false
     @State private var showSharePopover: Bool = false
     
     var body: some View {
@@ -19,13 +18,10 @@ struct ShareButton: View {
             if DeviceType.isPad() {
                 showSharePopover = true
             } else {
-                showShareSheet = true
+                postShowShareSheet(with: [generateText()])
             }
         }) {
             Image(systemName: "square.and.arrow.up")
-        }
-        .sheet(isPresented: $showShareSheet) {
-            ActivityView(activityItems: [generateText()])
         }
         .popover(isPresented: $showSharePopover) {
             ActivityView(activityItems: [generateText()])

--- a/Elsewhen/Extensions/NotificationName.swift
+++ b/Elsewhen/Extensions/NotificationName.swift
@@ -1,0 +1,14 @@
+//
+//  Notifications.swift
+//  Elsewhen
+//
+//  Created by David Stephens on 16/10/2021.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let EWShouldOpenShareSheet = Notification.Name("EWShouldOpenShareSheet")
+}
+
+let ActivityItemsKey = "activityItems"

--- a/Elsewhen/Helpers/SharingHelpers.swift
+++ b/Elsewhen/Helpers/SharingHelpers.swift
@@ -1,0 +1,33 @@
+//
+//  SharingHelpers.swift
+//  Elsewhen
+//
+//  Created by David Stephens on 16/10/2021.
+//
+
+import Foundation
+#if canImport(Cocoa)
+import Cocoa
+#endif
+#if canImport(UIKit)
+import UIKit
+#endif
+
+func postShowShareSheet(with items: [Any]) {
+    NotificationCenter.default.post(name: .EWShouldOpenShareSheet, object: appDelegate(), userInfo: [ActivityItemsKey: items])
+}
+
+#if os(macOS)
+func appDelegate() -> NSApplicationDelegate? {
+    return NSApp.delegate
+}
+#else
+func appDelegate() -> UIApplicationDelegate? {
+    return UIApplication.shared.delegate
+}
+#endif
+
+struct ShareSheetItem: Identifiable {
+    let id = UUID()
+    let items: [Any]
+}


### PR DESCRIPTION
Some share extensions that can be used from the share sheet open the keyboard. When the keyboard is opened on the iPhone, we remove the `ResultSheet` which the share sheet is attached to; this breaks the sharing process, manifesting as having to tap the receiving app's icon twice.