### PR TITLE
Added compact date picker to Myke Mode

### DIFF
--- a/Elsewhen/Elements/DateTimeZonePicker.swift
+++ b/Elsewhen/Elements/DateTimeZonePicker.swift
@@ -13,7 +13,7 @@ struct DateTimeZonePicker: View {
     // MARK: Parameters
     @Binding var selectedDate: Date
     @Binding var selectedTimeZone: TimeZone?
-    var showDate: Bool = true
+    var showFullCalendar: Bool = true
     let maxWidth: CGFloat?
     
     // MARK: State
@@ -50,7 +50,7 @@ private static let pickerStackSpacing: CGFloat = 5
     var body: some View {
         Group {
             
-            if showDate {
+            if showFullCalendar {
                 #if os(macOS)
                 HStack {
                     Button {
@@ -91,8 +91,8 @@ private static let pickerStackSpacing: CGFloat = 5
                         .datePickerStyle(Self.timePickerStyle)
                         .frame(maxWidth: selectTimeZoneButtonMaxWidth)
 #else
-                    DatePicker("Time", selection: $selectedDate, displayedComponents: [.hourAndMinute])
-                        .datePickerStyle(Self.timePickerStyle)
+                    DatePicker("Time", selection: $selectedDate, displayedComponents: [.date, .hourAndMinute])
+                        .datePickerStyle(.compact)
                         .labelsHidden()
                     Button(action: {
 #if os(iOS)
@@ -135,7 +135,7 @@ private static let pickerStackSpacing: CGFloat = 5
                 }
             }
             .padding(.bottom, 10)
-            .padding(.horizontal, showDate ? 8 : 0)
+            .padding(.horizontal, showFullCalendar ? 8 : 0)
             .frame(minWidth: 0, maxWidth: DeviceType.isPad() || DeviceType.isMac() ? maxWidth.map { $0 + 16 } : .infinity)
             .sheet(isPresented: $showTimeZoneChoiceSheet) {
                 NavigationView {
@@ -162,7 +162,7 @@ private extension DateTimeZonePicker {
 struct DateTimeZonePicker_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
-            DateTimeZonePicker(selectedDate: .constant(Date()), selectedTimeZone: .constant(TimeZone(identifier: "Europe/London")!), showDate: false, maxWidth: nil)
+            DateTimeZonePicker(selectedDate: .constant(Date()), selectedTimeZone: .constant(TimeZone(identifier: "Europe/London")!), showFullCalendar: false, maxWidth: nil)
         }
     }
 }

--- a/Elsewhen/Views/MykeMode.swift
+++ b/Elsewhen/Views/MykeMode.swift
@@ -226,7 +226,7 @@ struct MykeMode: View, OrientationObserving {
         
         Group {
             
-            DateTimeZonePicker(selectedDate: $selectedDate, selectedTimeZone: $selectedTimeZone, showDate: false, maxWidth: nil)
+            DateTimeZonePicker(selectedDate: $selectedDate, selectedTimeZone: $selectedTimeZone, showFullCalendar: false, maxWidth: nil)
                 .padding(.top, 5)
                 .padding(.horizontal, 8)
             


### PR DESCRIPTION
We need the ability to pick a date as well as a time in Myke Mode, in order to account for DST changes (not every time zone is offset from the rest by the same amount all year round, so assuming "today" for the date in Myke Mode causes inconsistent results).